### PR TITLE
Diameter i stedet for radius

### DIFF
--- a/kap7/kap7.md
+++ b/kap7/kap7.md
@@ -186,7 +186,7 @@ class Menneske {
     }
 
     draw() {
-   	 circle(this.x, this.y, this.radius);
+   	 circle(this.x, this.y, this.radius*2);
     }
 
     collision(windowWidth, windowHeight) {


### PR DESCRIPTION
circle bruger diameter som 3. argument, derfor skal radius ganges med 2.

https://p5js.org/reference/#/p5/circle